### PR TITLE
Implement configurable path sort order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+
 out
 node_modules
+npm-debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
+
+
 # Change Log
 
-## Future roadmap
-- Handle distinct blocks of imports separated by a blank line.
-- Handle comments within import blocks
-- Read settings from existing tslint configuration.
+## [1.2.0]
+- Added the ability to configure how sorting by import path is done.
+- Fixed a bug where the extension would process non-Typescript files when saving
 
 ## [1.1.0]
 - Added the option to sort imports whenever you save, controlled by the `typescript.extension.sortImports.sortOnSave` setting (`false` by default).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+
+
 # Sort Typescript imports
 
 Sort import statements in Typescript code
@@ -15,6 +18,11 @@ This configurable extension allows you to sort all the imports in a *.ts or *.ts
 * `typescript.extension.sortImports.sortMethod`: The method to use for sorting the imports.
   * `'importName'`(default) sorts by the type and name of the import. Namespace imports are first, followed by default imports, named imports, and unnamed imports.
   * `'path'` sorts by the import path, sorting relative-path imports above package imports
+* `typescript.extension.sortImports.pathSortOrder`: An array describing the order in which imports should be sorted by paths. Only applicable if `sortMethod` is set to `path`.
+  * Default: `["relativeDownLevel", "relativeUpLevel", "package"]`
+  * `package` - Any import path that does not begin with `.`
+  * `relativeUpLevel` - Any import path that begins with `../`
+  * `relativeDownLevel` - Any import path that begins with `./`
 * `typescript.extension.sortImports.maxNamedImportsInSingleLine`: The number of named imports to allow on a single line. If a single import has more than this number, they will be broken up onto separate lines.
 * `typescript.extension.sortImports.quoteStyle`: The type of quotation mark to use. `single`(default) or `double`.
 * `typescript.extension.sortImports.sortOnSave`: If set to `true`, imports will be sorted whenever you save a file. Default: `false`
@@ -23,7 +31,19 @@ This configurable extension allows you to sort all the imports in a *.ts or *.ts
 
 * This extension does not currently sort comments within the import block along with the import statements
 
+## Future roadmap
+- Handle distinct blocks of imports separated by a blank line.
+- Handle comments within import blocks
+- Read settings from existing tslint configuration.
+
 ## Release Notes
+
+### 1.2.0
+- Added the ability to configure how sorting by import path is done.
+- Fixed a bug where the extension would process non-Typescript files when saving
+
+### 1.1.0
+- Added the option to sort imports whenever you save, controlled by the `typescript.extension.sortImports.sortOnSave` setting (`false` by default).
 
 ### 1.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "sort-typescript-imports",
   "displayName": "Sort Typescript Imports",
@@ -68,8 +69,8 @@
             ]
           },
           "uniqueItems": true,
-          "minItems": 2,
-          "maxItems": 2,
+          "minItems": 3,
+          "maxItems": 3,
           "description": "When `sortMethod` is set to `path`, this controls the order to sort imports between package-level and path-relative imports. 'relativeUpLevel' describes relative paths that begin with '../', while ;relativeDownLevel' describes relative paths that begin with './'",
           "default": [
             "relativeDownLevel",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,8 @@
-
-
 {
   "name": "sort-typescript-imports",
   "displayName": "Sort Typescript Imports",
   "description": "Sorts import statements in Typescript code",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publisher": "miclo",
   "license": "MIT",
   "icon": "images/icon.png",
@@ -62,7 +60,7 @@
         "typescript.extension.sortImports.pathSortOrder": {
           "type": "array",
           "items": {
-            "type":"string",
+            "type": "string",
             "enum": [
               "package",
               "relativeUpLevel",
@@ -73,7 +71,11 @@
           "minItems": 2,
           "maxItems": 2,
           "description": "When `sortMethod` is set to `path`, this controls the order to sort imports between package-level and path-relative imports. 'relativeUpLevel' describes relative paths that begin with '../', while ;relativeDownLevel' describes relative paths that begin with './'",
-          "default": ["relativeDownLevel", "relativeUpLevel", "package"]
+          "default": [
+            "relativeDownLevel",
+            "relativeUpLevel",
+            "package"
+          ]
         },
         "typescript.extension.sortImports.maxNamedImportsInSingleLine": {
           "type": "number",

--- a/package.json
+++ b/package.json
@@ -1,3 +1,5 @@
+
+
 {
   "name": "sort-typescript-imports",
   "displayName": "Sort Typescript Imports",
@@ -56,6 +58,22 @@
           ],
           "description": "Whether to sort by the name of the import or the source path of the import",
           "default": "importName"
+        },
+        "typescript.extension.sortImports.pathSortOrder": {
+          "type": "array",
+          "items": {
+            "type":"string",
+            "enum": [
+              "package",
+              "relativeUpLevel",
+              "relativeDownLevel"
+            ]
+          },
+          "uniqueItems": true,
+          "minItems": 2,
+          "maxItems": 2,
+          "description": "When `sortMethod` is set to `path`, this controls the order to sort imports between package-level and path-relative imports. 'relativeUpLevel' describes relative paths that begin with '../', while ;relativeDownLevel' describes relative paths that begin with './'",
+          "default": ["relativeDownLevel", "relativeUpLevel", "package"]
         },
         "typescript.extension.sortImports.maxNamedImportsInSingleLine": {
           "type": "number",

--- a/src/isSupportedLanguage.ts
+++ b/src/isSupportedLanguage.ts
@@ -1,0 +1,5 @@
+
+export default function isSupportedLanguage(languageId: string) {
+    return languageId === 'typescript'
+        || languageId === 'typescriptreact';
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -30,6 +30,10 @@ export function shouldSortOnSave(): boolean {
     return getExtensionConfig().get('sortOnSave') as boolean;
 }
 
+export function getPathSortOrdering(): string[] {
+    return getExtensionConfig().get('pathSortOrder') as string[];
+}
+
 function getExtensionConfig() {
     return vscode.workspace.getConfiguration('typescript.extension.sortImports');
 }

--- a/src/processImports.ts
+++ b/src/processImports.ts
@@ -1,5 +1,5 @@
-import { TypescriptImport } from './TypescriptImport';
 import * as options from './options';
+import { TypescriptImport } from './TypescriptImport';
 
 export default function processImports(importClauses: TypescriptImport[]): TypescriptImport[] {
     return importClauses
@@ -34,12 +34,13 @@ function comparePath(a: TypescriptImport, b: TypescriptImport) {
 }
 
 function getPathPriority(path: string) {
-    if (/^\./.test(path)) {
-        return 0;
-    } else if (/^\.\./.test(path)) {
-        return 1;
+    let sortOrder = options.getPathSortOrdering();
+    if (/^\.\//.test(path)) {
+        return sortOrder.indexOf('relativeDownLevel');
+    } else if (/^\.\.\//.test(path)) {
+        return sortOrder.indexOf('relativeUpLevel');
     } else {
-        return 2;
+        return sortOrder.indexOf('package');
     }
 }
 

--- a/src/sortOnSave.ts
+++ b/src/sortOnSave.ts
@@ -1,8 +1,11 @@
 import * as vscode from 'vscode';
+import isSupportedLanguage from './isSupportedLanguage';
 import sortImports from './sortImports';
 
 export default function sortOnSave(event: vscode.TextDocumentWillSaveEvent) {
-    event.waitUntil(new Promise<vscode.TextEdit[]>((resolve, reject) => {
-        resolve(sortImports(event.document));
-    }));
+    if (isSupportedLanguage(event.document.languageId)) {
+        event.waitUntil(new Promise<vscode.TextEdit[]>((resolve, reject) => {
+            resolve(sortImports(event.document));
+        }));
+    }
 }


### PR DESCRIPTION
This addresses #2 .

Additionally, I fixed an oversight in the sort-on-save code, so it doesn't run for non-Typescript code.