### PR TITLE
1.2.1/parse package paths with at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.2.1]
 - Fix bug with package paths that contained an `@` symbol
+- Fix bug that would add a newline to the beginning of any file without import statements
 
 ## [1.2.0]
 - Added the ability to configure how sorting by import path is done.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-
-
 # Change Log
+
+## [1.2.1]
+- Fix bug with package paths that contained an `@` symbol
 
 ## [1.2.0]
 - Added the ability to configure how sorting by import path is done.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ This configurable extension allows you to sort all the imports in a *.ts or *.ts
 
 ### 1.2.0
 - Added the ability to configure how sorting by import path is done.
-- Fixed a bug where the extension would process non-Typescript files when saving
 
 ### 1.1.0
 - Added the option to sort imports whenever you save, controlled by the `typescript.extension.sortImports.sortOnSave` setting (`false` by default).

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
-
 {
   "name": "sort-typescript-imports",
   "displayName": "Sort Typescript Imports",
   "description": "Sorts import statements in Typescript code",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "publisher": "miclo",
   "license": "MIT",
   "icon": "images/icon.png",

--- a/src/parseImportNodes.ts
+++ b/src/parseImportNodes.ts
@@ -10,7 +10,7 @@ const destructingImportToken = `(${name})(\\s+as\\s+(${name}))?`;
 const destructingImport = `{(${ws}*${destructingImportToken}(,${ws}*${destructingImportToken})*${ws}*)}`;
 const defaultAndDestructingImport = `${defaultImportToken}${ws}*,${ws}*${destructingImport}`;
 const combinedImportTypes = `(${namespaceToken}|${defaultImportToken}|${destructingImport}|${defaultAndDestructingImport})`;
-const importRegexString = `^import\\s+(${combinedImportTypes}\\s+from\\s+)?['"]([\\w\\\\/\.-]+)['"];?\\r?\\n?`;
+const importRegexString = `^import\\s+(${combinedImportTypes}\\s+from\\s+)?['"]([@\\w\\\\/\.-]+)['"];?\\r?\\n?`;
 
 // Group 5 || Group 18 - default import
 // Group 3 - namespace import

--- a/src/writeImports.ts
+++ b/src/writeImports.ts
@@ -1,11 +1,13 @@
-import { TypescriptImport, NamedImport } from './TypescriptImport';
 import * as vscode from 'vscode';
 import * as options from './options';
+import { NamedImport, TypescriptImport } from './TypescriptImport';
 
 export default function getSortedImportStatements(importClauses: TypescriptImport[]): string {
-    return importClauses
-        .map(getImportClauseString)
-        .join('\n') + '\n';
+    if (importClauses && importClauses.length) {
+        return importClauses
+            .map(getImportClauseString)
+            .join('\n') + '\n';
+    }
 }
 
 function getImportClauseString(importClause: TypescriptImport): string {


### PR DESCRIPTION
Addresses #5.

Additionally addresses a bug where an extraneous newline was added whenever processing a file without any import statements.