### PR TITLE
Add support for removing whitespace for single line imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This configurable extension allows you to sort all the imports in a *.ts or *.ts
   * `package` - Any import path that does not begin with `.`
   * `relativeUpLevel` - Any import path that begins with `../`
   * `relativeDownLevel` - Any import path that begins with `./`
+* `typescript.extension.sortImports.bracketWhitespace`: If set to false whitespace will not be included in single line imports. Default: `true`
 * `typescript.extension.sortImports.maxNamedImportsInSingleLine`: The number of named imports to allow on a single line. If a single import has more than this number, they will be broken up onto separate lines.
 * `typescript.extension.sortImports.quoteStyle`: The type of quotation mark to use. `single`(default) or `double`.
 * `typescript.extension.sortImports.sortOnSave`: If set to `true`, imports will be sorted whenever you save a file. Default: `false`

--- a/package.json
+++ b/package.json
@@ -76,7 +76,12 @@
             "relativeUpLevel",
             "package"
           ]
-        },
+				},
+				"typescript.extension.sortImports.bracketWhitespace": {
+          "type": "boolean",
+          "description": "Whether or not to include whitespace between brackets of single line imports.",
+          "default": true
+					},
         "typescript.extension.sortImports.maxNamedImportsInSingleLine": {
           "type": "number",
           "description": "The maximum number of named imports to include in a single line",

--- a/src/options.ts
+++ b/src/options.ts
@@ -42,6 +42,10 @@ export function getOmitSemicolon(): boolean {
     return getExtensionConfig().get('omitSemicolon') as boolean;
 }
 
+export function getBracketWhitespace(): boolean {
+	return getExtensionConfig().get('bracketWhitespace') as boolean;
+}
+
 function getExtensionConfig() {
     return vscode.workspace.getConfiguration('typescript.extension.sortImports');
 }

--- a/src/writeImports.ts
+++ b/src/writeImports.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
 import * as options from './options';
 import { NamedImport, TypescriptImport } from './TypescriptImport';
+import * as vscode from 'vscode';
 
 export default function getSortedImportStatements(importClauses: TypescriptImport[]): string {
     if (importClauses && importClauses.length) {
@@ -42,9 +42,11 @@ function generatedNamedImportGroup(namedImports: NamedImport[]): string {
     if (generatedNamedImports.length > maxImportsPerSingleLine) {
         let newline = `\n${options.getTabString()}`;
         return `{${newline}${generatedNamedImports.join(`,${newline}`)}${newline}}`;
-    } else {
+    } else if (options.getBracketWhitespace()) {
         return `{ ${generatedNamedImports.join(', ')} }`;
-    }
+    } else {
+		return `{${generatedNamedImports.join(', ')}}`;
+	}
 }
 
 function generateNamedImport(namedImport: NamedImport): string {


### PR DESCRIPTION
Hello!

This PR adds support for removing the whitespace from single line imports like so

`import {'foo'} from 'bar';`

as opposed to 

`import { 'foo' } from 'bar';`